### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/graphcore/query.py
+++ b/graphcore/query.py
@@ -56,9 +56,9 @@ class Query(object):
         return self.clauses[index]
 
     def __str__(self):
-        return '[\n%s]' % ''.join(
+        return '[\n{0!s}]'.format(''.join(
             '  ' + str(clause) + '\n' for clause in self.clauses
-        )
+        ))
 
     def __repr__(self):
         return '<Query {}>'.format(str(self))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:dwiel:graphcore?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:dwiel:graphcore?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
